### PR TITLE
TraceIterator requires C++17

### DIFF
--- a/include/fstrace.h
+++ b/include/fstrace.h
@@ -303,6 +303,8 @@ const char *fstrace_hex_repr(uint64_t n);
 #ifdef __cplusplus
 }
 
+#if __cplusplus >= 201703L
+
 #include <cassert>
 #include <string>
 #include <type_traits>
@@ -383,6 +385,8 @@ struct TraceIterator {
 
 } // namespace fstrace
 } // namespace fsecure
+
+#endif // #if __cplusplus >= 201703L
 
 #endif
 


### PR DESCRIPTION
Currently if a source file that is compiled with C++14 or older standard
includes fstrace.h, the build fails as the header requires C++17.

Add C++ version check around TraceIterator class and only expose it if
the including compilation unit is compiled with at least C++17.