### PR TITLE
fstracecheck2: fix processing of macOS multi-arch commands

### DIFF
--- a/bin/fstracecheck2
+++ b/bin/fstracecheck2
@@ -145,11 +145,16 @@ FSTRACECHECK %a
 
 
 def form_tstcmd(argv, dirpath, pathname, test_source):
+    arch = False
     obj = False
     for arg in argv:
         if obj:
             obj = False
             yield test_source + ".i"
+        elif arg == "-arch":
+            arch = True
+        elif arch:
+            arch = False
         elif arg == "-c":
             yield "-E"
         elif arg == "-o":
@@ -210,11 +215,16 @@ def pp_ext(pathname):
 
 
 def form_ppcmd(argv, dirpath, pathname, x_output):
+    arch = False
     obj = False
     for arg in argv:
         if obj:
             obj = False
             yield x_output
+        elif arg == "-arch":
+            arch = True
+        elif arch:
+            arch = False
         elif arg == "-c":
             yield "-E"
         elif arg == "-o":


### PR DESCRIPTION
macOS clang supports building a universal object file, by specifying
multiple '-arch' options. Preprocessing a source file for multiple
architectures is however not possible, and causes fstracecheck2 to
fail when a command includes multiple '-arch' options. This commit
changes fstracecheck2 to support such commands by filtering out
'-arch' options, which has the effect of testing only the host
architecture. While in theory it would be preferable to test all the
specified architectures, in practice it should be enough to test one
as types should not differ in size among 64-bit architectures.